### PR TITLE
Add unread notification endpoints to NotificationsController

### DIFF
--- a/CookbookApp.APi/Controllers/NotificationsController.cs
+++ b/CookbookApp.APi/Controllers/NotificationsController.cs
@@ -52,6 +52,50 @@ namespace CookbookApp.APi.Controllers
 
             return Ok(result);
         }
+        //get unread count
+        [HttpGet("unread-count")]
+        [Authorize]
+        public async Task<IActionResult> GetUnreadNotificationCount()
+        {
+            var userIdClaim = User.FindFirst("id") ?? User.FindFirst("sub") ?? User.FindFirst(ClaimTypes.NameIdentifier);
+            if (userIdClaim == null)
+                return Unauthorized("User ID not found");
+
+            int userId = int.Parse(userIdClaim.Value);
+
+            var count = await _context.Notifications
+                .Where(n => n.UserId == userId && !n.IsRead)
+                .CountAsync();
+
+            return Ok(count);
+        }
+
+        //mark-as-read
+        [HttpPost("mark-as-read")]
+        [Authorize]
+        public async Task<IActionResult> MarkAllAsRead()
+        {
+            var userIdClaim = User.FindFirst("id") ?? User.FindFirst("sub") ?? User.FindFirst(ClaimTypes.NameIdentifier);
+            if (userIdClaim == null)
+                return Unauthorized("User ID not found");
+
+            int userId = int.Parse(userIdClaim.Value);
+
+            var unreadNotifications = await _context.Notifications
+                .Where(n => n.UserId == userId && !n.IsRead)
+                .ToListAsync();
+
+            foreach (var notification in unreadNotifications)
+            {
+                notification.IsRead = true;
+            }
+
+            await _context.SaveChangesAsync();
+
+            return Ok();
+        }
+
+
 
     }
 }


### PR DESCRIPTION
Implemented two new API endpoints: GetUnreadNotificationCount to fetch the count of unread notifications and MarkAllAsRead to mark all unread notifications as read. Both methods include authorization checks and utilize user claims for identification.